### PR TITLE
chore: Init rust-overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,45 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1720837122,
+        "narHash": "sha256-WMwo/kZ3o2h5Bls4dEyQ3XFZ4nw2UbbOUFpq3aVlkms=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "92f0608ab66c9770e931056b1c7a1b6249dbc43a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,15 +15,28 @@
           inherit system overlays;
         };
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        rust-nightly = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
       in {
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = [
-            pkgs.libiconv
-            rust
-          ];
-          shellHook = ''
-            exec $SHELL
-          '';
+        devShells = {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [
+              pkgs.libiconv
+              rust
+            ];
+            shellHook = ''
+              exec $SHELL
+            '';
+          };
+
+          nightly = pkgs.mkShell {
+            nativeBuildInputs = [
+              pkgs.libiconv
+              rust-nightly
+            ];
+            shellHook = ''
+              exec $SHELL
+            '';
+          };
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
           inherit system overlays;
         };
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        rust-beta = pkgs.rust-bin.beta.latest.default;
         rust-nightly = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
       in {
         devShells = {
@@ -22,6 +23,16 @@
             nativeBuildInputs = [
               pkgs.libiconv
               rust
+            ];
+            shellHook = ''
+              exec $SHELL
+            '';
+          };
+
+          beta = pkgs.mkShell {
+            nativeBuildInputs = [
+              pkgs.libiconv
+              rust-beta
             ];
             shellHook = ''
               exec $SHELL

--- a/flake.nix
+++ b/flake.nix
@@ -4,21 +4,22 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = { nixpkgs, flake-utils, ... }:
+  outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
+        overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
-          inherit system;
+          inherit system overlays;
         };
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
       in {
         devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [
-            libiconv
-          ];
-          buildInputs = with pkgs; [
-            rustup
+          nativeBuildInputs = [
+            pkgs.libiconv
+            rust
           ];
           shellHook = ''
             exec $SHELL


### PR DESCRIPTION
# Why did I create this pull request?
せっかく`rust-toolchain.toml`を使用しているのだから、[rust-overlay](https://github.com/oxalica/rust-overlay)の`fromRustupToolchainFile`関数を使うのはどうだろうかという案。但し、`rustup`を使用する事自体が重要な場合はこの方法は使用出来ない為、遠慮なくクローズして欲しい。